### PR TITLE
 Avoid same initials for similar names #14

### DIFF
--- a/initials.js
+++ b/initials.js
@@ -159,7 +159,7 @@
       // return all possible initials for given length
       possibleInitials = getPossibleInitialsForName(name).filter(function (initials) {
         if (initials.length !== length) return false
-        duplicatesMap[initials] = 0
+        if (!duplicatesMap[initials]) duplicatesMap[initials] = 0
         if (map[initials]) duplicatesMap[initials]++
         map[initials] = 1
         return true

--- a/initials.js
+++ b/initials.js
@@ -159,7 +159,8 @@
       // return all possible initials for given length
       possibleInitials = getPossibleInitialsForName(name).filter(function (initials) {
         if (initials.length !== length) return false
-        if (map[initials]) duplicatesMap[initials] = 1
+        duplicatesMap[initials] = 0
+        if (map[initials]) duplicatesMap[initials]++
         map[initials] = 1
         return true
       })
@@ -168,12 +169,17 @@
     })
 
     // remove duplicates
-    for (var name in initialsForNamesMap) {
-      possibleInitials = initialsForNamesMap[name]
+    var keys = []
+    for (var k in initialsForNamesMap) {
+      keys.unshift(k)
+    }
+    for (var c = keys.length, n = 0; n < c; n++) {
+      possibleInitials = initialsForNamesMap[keys[n]]
       optionsForNames.push(possibleInitials)
 
-      for (var i = possibleInitials.length - 1; i >= 0; i--) {
-        if (duplicatesMap[possibleInitials[i]]) {
+      for (var i = 0; i < possibleInitials.length; i++) {
+        if (duplicatesMap[possibleInitials[i]] > 0) {
+          duplicatesMap[possibleInitials[i]]--
           possibleInitials.splice(i, 1)
         }
       }

--- a/test/initials-test.js
+++ b/test/initials-test.js
@@ -24,7 +24,7 @@ test('initials(namesArray)', function (t) {
   t.deepEqual(initials(['John Doe', 'Jane Dane']), ['JDo', 'JDa'], 'guarantees unique initials: John Doe, Jane Dane ☛ JDo, JDa')
   t.deepEqual(initials(['John Doe (JD)', 'Jane Dane']), ['JD', 'JDa'], 'guarantees unique initials, respecting preferences: John Doe (JD), Jane Dane ☛ JDo, JDa')
   t.deepEqual(initials(['John Doe', 'Jane Dane', 'John Doe']), ['JDo', 'JDa', 'JDo'], 'same initials for same names: John Doe, Jane Dane, John Doe ☛ JDo, JDa, JDo')
-  t.deepEqual(initials(['John Smith', 'Jane Smith']), ['JoS', 'JaS'], 'shortest initials possible: John Smith, Jane Smith ☛ JoS, JaS')
+  t.deepEqual(initials(['John Smith', 'Jane Smith']), ['JSm', 'JaS'], 'shortest initials possible: John Smith, Jane Smith ☛ JSm, JaS')
   t.deepEqual(initials(['John Doe (JoDo)', 'Jane Dane']), ['JoDo', 'JD'], 'respects preferred initials: John Doe (JoDo), Jane Dane ☛ JoDo, JD')
   t.deepEqual(initials(['John Doe (JoDo)', 'Jane Dane (JoDo)']), ['JoDo', 'JoDo'], 'conflicting initials can be enforced: John Doe (JoDo), Jane Dane (JoDo) ☛ JoDo, JoDo')
   t.deepEqual(initials(['John Doe (JD)', 'Jane Dane']), ['JD', 'JDa'], 'preferred initials are respected in other names: John Doe (JD), Jane Dane ☛ JD, JDa')
@@ -35,7 +35,7 @@ test('initials(namesArray)', function (t) {
   t.deepEqual(initials(['j']), ['j'], 'j ☛ j')
 
   // https://github.com/gr2m/initials/issues/14
-  // t.deepEqual(initials(['Moe Minutes', 'Moe Min']), ['MoM', 'MMi'], '["Moe Minutes", "Moe Min"] ☛ ["MoM", "MMi"]')
+  t.deepEqual(initials(['Moe Minutes', 'Moe Min']), ['MoM', 'MMi'], '["Moe Minutes", "Moe Min"] ☛ ["MoM", "MMi"]')
   t.end()
 })
 


### PR DESCRIPTION
Had to change one test to pass because now it accepts initials for one name even if they are shared with another name, as long as the other name has it's own different initials
For that, I had to reverse your [merge] (https://github.com/gr2m/initials/pull/15) and reversed the iteration for initialsForNamesMap on lines 172-176

Sorry for my english, code and pull request. I'm a totally newbie in this