### PR TITLE
Add generic type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare module 'initials' {
 		}
 	}
 
-	function initials(nameOrNames: NameOrNames, options?: Options): string | string[];
+	function initials<T extends NameOrNames>(nameOrNames: T, options?: Options): T;
 
 	export function find(name: string): string;
 


### PR DESCRIPTION
Fixes #81 

Adds a generic for the `initials` function so the correct result will be returned based on the input type.  TypeScript will infer it automatically, so this requires no change by the user.